### PR TITLE
Fix panic on unhealthy coordinators in UserAwareRouter rules

### DIFF
--- a/pkg/proxy/lb/proxy.go
+++ b/pkg/proxy/lb/proxy.go
@@ -112,7 +112,7 @@ func (p *Proxy) selectCoordinatorForRequest(request *http.Request) (CoordinatorR
 
 		targetCoordinator, err := p.router.Route(routingRequest(healthyCoordinators, request))
 		if err != nil {
-			if errors.Is(err, routing.ErrRoutingNotFound) {
+			if errors.Is(err, routing.ErrRouteNotFound) {
 				return CoordinatorRef{}, fmt.Errorf("%w: %w", err, ErrNoBackendsAvailable)
 			}
 			return CoordinatorRef{}, err

--- a/pkg/proxy/lb/proxy.go
+++ b/pkg/proxy/lb/proxy.go
@@ -113,7 +113,7 @@ func (p *Proxy) selectCoordinatorForRequest(request *http.Request) (CoordinatorR
 		targetCoordinator, err := p.router.Route(routingRequest(healthyCoordinators, request))
 		if err != nil {
 			if errors.Is(err, routing.ErrRouteNotFound) {
-				return CoordinatorRef{}, fmt.Errorf("%w: %w", err, ErrNoBackendsAvailable)
+				return CoordinatorRef{}, fmt.Errorf("%s: %w", err.Error(), ErrNoBackendsAvailable)
 			}
 			return CoordinatorRef{}, err
 		}

--- a/pkg/proxy/lb/proxy.go
+++ b/pkg/proxy/lb/proxy.go
@@ -112,6 +112,9 @@ func (p *Proxy) selectCoordinatorForRequest(request *http.Request) (CoordinatorR
 
 		targetCoordinator, err := p.router.Route(routingRequest(healthyCoordinators, request))
 		if err != nil {
+			if errors.Is(err, routing.ErrRoutingNotFound) {
+				return CoordinatorRef{}, fmt.Errorf("%w: %w", err, ErrNoBackendsAvailable)
+			}
 			return CoordinatorRef{}, err
 		}
 

--- a/pkg/proxy/lb/proxy.go
+++ b/pkg/proxy/lb/proxy.go
@@ -1,6 +1,7 @@
 package lb
 
 import (
+	"errors"
 	"fmt"
 	"github.com/The-Data-Appeal-Company/trino-loadbalancer/pkg/common/logging"
 	"github.com/The-Data-Appeal-Company/trino-loadbalancer/pkg/proxy/healthcheck"
@@ -70,7 +71,7 @@ func (p *Proxy) Serve(addr string) error {
 
 func (p *Proxy) Handle(writer http.ResponseWriter, request *http.Request) {
 	coordinator, err := p.selectCoordinatorForRequest(request)
-	if err == ErrNoBackendsAvailable {
+	if errors.Is(err, ErrNoBackendsAvailable) {
 		p.logger.Warn("no available backends for request %s", request.URL)
 		writer.WriteHeader(http.StatusServiceUnavailable)
 		if _, err := writer.Write([]byte(err.Error())); err != nil {

--- a/pkg/proxy/routing/router.go
+++ b/pkg/proxy/routing/router.go
@@ -44,7 +44,7 @@ func (r Router) Route(req Request) (models.Coordinator, error) {
 	}
 
 	if len(req.Coordinators) == 0 {
-		return models.Coordinator{}, ErrRoutingNotFound
+		return models.Coordinator{}, ErrRouteNotFound
 	}
 
 	return r.Rule.Route(req)

--- a/pkg/proxy/routing/router.go
+++ b/pkg/proxy/routing/router.go
@@ -42,7 +42,7 @@ func (r Router) Route(req Request) (models.Coordinator, error) {
 	if err != nil {
 		return models.Coordinator{}, fmt.Errorf("error routing request: %w", err)
 	}
-	 
+
 	if len(req.Coordinators) == 0 {
 		return models.Coordinator{}, ErrRoutingNotFound
 	}

--- a/pkg/proxy/routing/router.go
+++ b/pkg/proxy/routing/router.go
@@ -42,6 +42,10 @@ func (r Router) Route(req Request) (models.Coordinator, error) {
 	if err != nil {
 		return models.Coordinator{}, fmt.Errorf("error routing request: %w", err)
 	}
+	 
+	if len(req.Coordinators) == 0 {
+		return models.Coordinator{}, ErrRoutingNotFound
+	}
 
 	return r.Rule.Route(req)
 }

--- a/pkg/proxy/routing/user_aware.go
+++ b/pkg/proxy/routing/user_aware.go
@@ -7,6 +7,7 @@ import (
 
 var (
 	ErrForbiddenRouting = errors.New("no route match for user")
+	ErrRoutingNotFound  = errors.New("no routable cluster")
 )
 
 type NoMatchBehaviour string

--- a/pkg/proxy/routing/user_aware.go
+++ b/pkg/proxy/routing/user_aware.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	ErrForbiddenRouting = errors.New("no route match for user")
-	ErrRoutingNotFound  = errors.New("no routable cluster")
+	ErrRouteNotFound    = errors.New("no routable cluster")
 )
 
 type NoMatchBehaviour string


### PR DESCRIPTION
Handle cases when the `UserAwareRouter` handles healthy clusters but none of them matches routing rule for the given `username`  