### PR TITLE
scale down even with running query 

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,10 +10,10 @@ jobs:
         go: ['1.19']
 
     steps:
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: go test -v -coverprofile=profile.cov ./...
 
       - name: Send coverage

--- a/example/config.yml
+++ b/example/config.yml
@@ -80,6 +80,7 @@ controller:
       min: "0"
       max: "5"
       scaleAfter: "10m"
+      scaleDownWithRunningQuery: true
   features:
     slow_worker_drainer:
       enabled: true

--- a/pkg/cmd/autoscaler.go
+++ b/pkg/cmd/autoscaler.go
@@ -58,13 +58,14 @@ var autoscalerCmd = &cobra.Command{
 						}
 
 						err = autoscalerController.Execute(autoscaler.KubeRequest{
-							Coordinator:  coordUri,
-							Namespace:    cluster.Namespace,
-							Deployment:   cluster.Deployment,
-							Min:          cluster.Min,
-							Max:          cluster.Max,
-							ScaleAfter:   cluster.ScaleAfter,
-							DynamicScale: cluster.DynamicScale,
+							Coordinator:               coordUri,
+							Namespace:                 cluster.Namespace,
+							Deployment:                cluster.Deployment,
+							Min:                       cluster.Min,
+							Max:                       cluster.Max,
+							ScaleAfter:                cluster.ScaleAfter,
+							DynamicScale:              cluster.DynamicScale,
+							ScaleDownWithRunningQuery: cluster.ScaleDownWithRunningQuery,
 						})
 
 						if err != nil {

--- a/pkg/configuration/controller.go
+++ b/pkg/configuration/controller.go
@@ -18,13 +18,14 @@ type ControllerConf struct {
 type AutoscalerConf struct {
 	Enabled    bool `yaml:"enabled" json:"enabled"`
 	Kubernetes []struct {
-		CoordinatorUri string                 `json:"coordinatorUri,omitempty" yaml:"coordinatorUri,omitempty"`
-		Namespace      string                 `yaml:"namespace" json:"namespace,omitempty"`
-		Deployment     string                 `json:"deployment,omitempty" yaml:"deployment,omitempty"`
-		Min            int                    `json:"min,omitempty" yaml:"min,omitempty"`
-		Max            int                    `json:"max,omitempty" yaml:"max,omitempty"`
-		ScaleAfter     time.Duration          `json:"scaleAfter" yaml:"scaleAfter"`
-		DynamicScale   AutoscalerDynamicScale `yaml:"dynamicScale" json:"dynamicScale"`
+		CoordinatorUri            string                 `json:"coordinatorUri,omitempty" yaml:"coordinatorUri,omitempty"`
+		Namespace                 string                 `yaml:"namespace" json:"namespace,omitempty"`
+		Deployment                string                 `json:"deployment,omitempty" yaml:"deployment,omitempty"`
+		Min                       int                    `json:"min,omitempty" yaml:"min,omitempty"`
+		Max                       int                    `json:"max,omitempty" yaml:"max,omitempty"`
+		ScaleAfter                time.Duration          `json:"scaleAfter" yaml:"scaleAfter"`
+		DynamicScale              AutoscalerDynamicScale `yaml:"dynamicScale" json:"dynamicScale"`
+		ScaleDownWithRunningQuery bool                   `yaml:"scaleDownWithRunningQuery" json:"scaleDownWithRunningQuery"`
 	} `yaml:"kubernetes" json:"kubernetes"`
 }
 

--- a/pkg/controller/autoscaler/state.go
+++ b/pkg/controller/autoscaler/state.go
@@ -10,21 +10,30 @@ type State interface {
 	SetLastQueryExecution(clusterID string, t time.Time) error
 	GetClusterInstances(clusterID string) (int32, error)
 	SetClusterInstances(clusterID string, i int32) error
+	SetLastScaleUp(clusterID string, i int32, t time.Time) error
+	GetLastScaleUp(clusterID string) (int32, time.Time, error)
 }
-
 type InMemory struct {
 	stateTime      map[string]time.Time
 	stateInstances map[string]int32
+	stateScaleUp   map[string]ScaleUpState
+}
+
+type ScaleUpState struct {
+	instances int32
+	time      time.Time
 }
 
 func MemoryState() *InMemory {
 	return &InMemory{
 		stateTime:      make(map[string]time.Time),
 		stateInstances: make(map[string]int32),
+		stateScaleUp:   make(map[string]ScaleUpState),
 	}
 }
 
 var NoInstancesInStateError = errors.New("no instances state")
+var NoLastScaleUpStateError = errors.New("no Last Scale Up state")
 
 func (i *InMemory) LastQueryExecution(clusterID string) (time.Time, error) {
 	return i.stateTime[clusterID], nil
@@ -48,11 +57,30 @@ func (i *InMemory) SetClusterInstances(clusterID string, instances int32) error 
 	return nil
 }
 
+func (i *InMemory) GetLastScaleUp(clusterID string) (int32, time.Time, error) {
+	value, ok := i.stateScaleUp[clusterID]
+	if !ok {
+		return 0, time.Now(), NoLastScaleUpStateError
+	}
+	return value.instances, value.time, nil
+}
+
+func (i *InMemory) SetLastScaleUp(clusterID string, ii int32, t time.Time) error {
+	state := ScaleUpState{
+		instances: ii,
+		time:      t,
+	}
+	i.stateScaleUp[clusterID] = state
+	return nil
+}
+
 type mockState struct {
-	setTime      func(clusterID string, t time.Time) error
-	getTime      func(clusterID string) (time.Time, error)
-	setInstances func(clusterID string, i int32) error
-	getInstances func(clusterID string) (int32, error)
+	setTime        func(clusterID string, t time.Time) error
+	getTime        func(clusterID string) (time.Time, error)
+	setInstances   func(clusterID string, i int32) error
+	getInstances   func(clusterID string) (int32, error)
+	setLastScaleUp func(clusterID string, i int32, t time.Time) error
+	getLastScaleUp func(clusterID string) (int32, time.Time, error)
 }
 
 func (m mockState) LastQueryExecution(clusterID string) (time.Time, error) {
@@ -69,4 +97,12 @@ func (m mockState) GetClusterInstances(clusterID string) (int32, error) {
 
 func (m mockState) SetClusterInstances(clusterID string, i int32) error {
 	return m.setInstances(clusterID, i)
+}
+
+func (m mockState) GetLastScaleUp(clusterID string) (int32, time.Time, error) {
+	return m.getLastScaleUp(clusterID)
+}
+
+func (m mockState) SetLastScaleUp(clusterID string, ii int32, t time.Time) error {
+	return m.setLastScaleUp(clusterID, ii, t)
 }


### PR DESCRIPTION
if no query that want the current number of instances is done in the wanted timeframe the cluster can resize to a lower number of instances